### PR TITLE
Fix Bundle.entry:Patient cardinality to 1..*

### DIFF
--- a/input/fsh/profiles/ChLabOrderDocumentWithSR.fsh
+++ b/input/fsh/profiles/ChLabOrderDocumentWithSR.fsh
@@ -35,6 +35,11 @@ equal one Filler Order equal one Laboratory Service Request."
 * entry[Composition].resource 1..
 * entry[Composition].resource only ChLabOrderCompositionWithSR
 
+// ---------- Bundle.entry:Patient ----------
+* entry[Patient] 1..*
+* entry[Patient] ^short = "Patient"
+* entry[Patient].resource 1..
+* entry[Patient].resource only CHCorePatient
 
 // the entries below are not mandatory, but they are useful for the lab order
 // and the lab order document to suppress the informations about slicing mismatches. But there are issues

--- a/input/fsh/profiles/ChLabOrderDocumentWithSR_AndForm.fsh
+++ b/input/fsh/profiles/ChLabOrderDocumentWithSR_AndForm.fsh
@@ -32,3 +32,9 @@ Consequently one CH Lab-Order Document contains one CH Lab-Order ServiceRequest 
 * entry[Composition] ^short = "Lab order composition"
 * entry[Composition].resource 1..
 * entry[Composition].resource only ChLabOrderCompositionWithSR_AndForm
+
+// ---------- Bundle.entry:Patient ----------
+* entry[Patient] 1..*
+* entry[Patient] ^short = "Patient"
+* entry[Patient].resource 1..
+* entry[Patient].resource only CHCorePatient

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -7,6 +7,9 @@ All significant changes to this FHIR implementation guide will be documented on 
 * [#385](https://github.com/hl7ch/ch-lab-order/issues/385): A future published Order Catalogue IG is based on R5 and this IG is based on FHIR R4. Decision to remove Catalogue dependency and examples from this IG: Removed ObservationDefinition, PlanDefinition, ActivityDefinition, and Catalog (Composition profile) resources and profiles. Removed Use Case 5 from documentation.
 * [#362](https://github.com/hl7ch/ch-lab-order/issues/362): Changelog
 
+#### Fixed
+* [#376](https://github.com/hl7ch/ch-lab-order/issues/376): Fixed Bundle.entry:Patient cardinality from 0..* to 1..* in document profiles. Since Composition.subject is 1..1 and must reference a Patient, and the Bundle is declared as type 'document' (meaning all references must be contained within the Bundle), the Patient entry must be present. Updated both ChLabOrderDocumentWithSR and ChLabOrderDocumentWithSR_AndForm profiles.
+
 ### STU 3 Ballot v3.0.0-ballot (2025-05-22)
 
 #### Changed / Updated 


### PR DESCRIPTION
## Summary
Fixes the cardinality of Bundle.entry:Patient from 0..* to 1..* in both document profiles to ensure consistency with Composition.subject requirements.

## Issue Addressed
**#376**: Question about why Bundle.entry:Patient cardinality is 0..* when Composition.subject is 1..1 and must reference the Patient.

Fixes #376